### PR TITLE
Fix incorrect error message when using a platform image without storage_service_name parameter

### DIFF
--- a/azure/errors.go
+++ b/azure/errors.go
@@ -2,4 +2,4 @@ package azure
 
 import "errors"
 
-var PlatformStorageError = errors.New("When using a platform image, the 'storage' parameter is required")
+var PlatformStorageError = errors.New("When using a platform image, the 'storage_service_name' parameter is required")


### PR DESCRIPTION
Hi there,

Derived from the following question of Stack Overflow:
https://stackoverflow.com/questions/44947178/create-ubuntu-server-resource-on-azure-with-terraform-io

```
* azure_instance.web: When using a platform image, the 'storage' parameter is required
```

I think an error message when using a platform image without `storage_service_name` parameter looks strange and probably wrong.

Fixing the error message itself is easy, so I fixed it, but actually I'm not an Azure user 😅 
So, please check this fix is doing the right thing 😇 